### PR TITLE
Improve the `Error` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 specifically the [variant used by Rust](http://doc.crates.io/manifest.html#the-version-field).
 
 ## [0.3.0] - 2019-05-06
+### Added
+- The `Error` type now implements `Clone`.
+
 ### Changed
 - `AsByteSlice::as_byte_slice` and `ToByteSlice::to_byte_slice` were changed to always return `&[u8]` instead of `Result<&[u8], Error>`.
 - `AsMutByteSlice::as_mut_byte_slice` and `ToMutByteSlice::to_mut_byte_slice` were changed to always return `&mut [u8]` instead of `Result<&mut [u8], Error>`.
+- The `Display` impl for `Error` now produces more detailed error messages.
+- The variants of the `Error` enum were renamed.
 
 ## [0.2.0] - 2018-06-01
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::slice;
 use std::error::Error as StdError;
 
 /// Possible errors during slice conversion.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The input slice is not properly aligned for the
     /// output data type. E.g. for an `u32` output slice


### PR DESCRIPTION
So there are a few things I want to point out:

1. Unfortunately the [type_name](https://doc.rust-lang.org/std/intrinsics/fn.type_name.html) intrinsic [is still unstable](https://github.com/rust-lang/rfcs/issues/1428), so by default the error messages will look like this:

```
cannot cast a &[u8] into a &[<Rust type>]: the slice's address is not divisible by the minimum alignment (2) of <Rust type> [turn on the \"nightly\" feature of the `byte-slice-cast` crate to see the actual type name]
```

and like this:

```
cannot cast a &[u8] into a &[<Rust type>]: the size (15) of the slice is not divisible by the size (2) of <Rust type> [turn on the \"nightly\" feature of the `byte-slice-cast` crate to see the actual type name]
```

I've added a disabled-by-default feature `nightly` which can be used by the user to enable the use of `type_name` and get the actual type name in the error message.

With the feature enabled those two error messages look like this:

```
cannot cast a &[u8] into a &[u16]: the slice's address is not divisible by the minimum alignment (2) of u16
```

and:

```
cannot cast a &[u8] into a &[u16]: the size (15) of the slice is not divisible by the size (2) of u16
```

Hopefully once `type_name` stabilizes we can just make this the default and make the `nightly` feature a no-op.

2. I've renamed the error variants. This is very bikesheddy and I don't really have a good argument why I like them more this way (I just think they're nicer), so if you prefer the old names please do tell me and I'll be happy to revert.