### PR TITLE
Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rust:
   - stable
   - beta
   - nightly
+script:
+  - cargo test
+  - cargo test --no-default-features
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "byte-slice-cast"
 version = "0.3.1"
 authors = ["Sebastian Dröge <sebastian@centricular.com>"]
 description = "Safely cast bytes slices from/to slices of built-in fundamental numeric types"
+keywords = ["no_std"]
 repository = "https://github.com/sdroege/bytes-num-slice-cast"
 license = "MIT"
 readme = "README.md"
@@ -15,6 +16,10 @@ include = [
 ]
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []
 
 [badges]
 travis-ci = { repository = "sdroege/byte-slice-cast", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ include = [
     "README.md",
     "CHANGELOG.md",
 ]
+edition = "2018"
 
 [dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-use std::{fmt, mem, slice, error::Error as StdError};
-#[cfg(not(feature = "std"))]
 use core::{fmt, mem, slice};
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
 
 /// Possible errors during slice conversion.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -191,10 +190,10 @@ where
 {
     /// Convert from an immutable byte slice to a immutable slice of a fundamental, built-in
     /// numeric type
-    fn from_byte_slice<T: AsRef<[u8]> + ?Sized>(&T) -> Result<&[Self], Error>;
+    fn from_byte_slice<T: AsRef<[u8]> + ?Sized>(_: &T) -> Result<&[Self], Error>;
     /// Convert from an mutable byte slice to a mutable slice of a fundamental, built-in numeric
     /// type
-    fn from_mut_byte_slice<T: AsMut<[u8]> + ?Sized>(&mut T) -> Result<&mut [Self], Error>;
+    fn from_mut_byte_slice<T: AsMut<[u8]> + ?Sized>(_: &mut T) -> Result<&mut [Self], Error>;
 }
 
 /// Trait for converting from an immutable slice of a fundamental, built-in numeric type to an
@@ -468,6 +467,7 @@ mod tests {
         assert_eq!(&input, output2);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn u16() {
         let slice: [u16; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
@@ -680,6 +680,7 @@ mod tests {
         assert_eq!(bytes.as_mut_slice_of::<u16>(), Ok(slice.as_mut()));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn u16_vec() {
         let vec: Vec<u16> = vec![0, 1, 2, 3, 4, 5, 6, 7];
@@ -709,6 +710,7 @@ mod tests {
         assert_eq!(bytes.as_slice_of::<u16>(), Ok(vec.as_ref()));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn u16_mut_vec() {
         let mut vec: Vec<u16> = vec![0, 1, 2, 3, 4, 5, 6, 7];
@@ -739,6 +741,7 @@ mod tests {
         assert_eq!(bytes.as_mut_slice_of::<u16>(), Ok(vec.as_mut()));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn u16_box_slice() {
         let vec: Box<[u16]> = vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice();
@@ -768,6 +771,7 @@ mod tests {
         assert_eq!(bytes.as_slice_of::<u16>(), Ok(vec.as_ref()));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn u16_mut_box_slice() {
         let mut vec: Box<[u16]> = vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,12 @@
 //! # }
 //! ```
 
-use std::fmt;
-use std::mem;
-use std::slice;
+#![cfg_attr(not(feature = "std"), no_std)]
 
-use std::error::Error as StdError;
+#[cfg(feature = "std")]
+use std::{fmt, mem, slice, error::Error as StdError};
+#[cfg(not(feature = "std"))]
+use core::{fmt, mem, slice};
 
 /// Possible errors during slice conversion.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,6 +122,7 @@ trait TypeName {
     const TYPE_NAME: &'static str;
 }
 
+#[cfg(feature = "std")]
 impl StdError for Error {
     fn description(&self) -> &str {
         use self::Error::*;


### PR DESCRIPTION
I would like to use this crate in `no_std` environment. Fortunately, it is really easy to support it, though currently the tests allocate memory and don’t work with `no_std`. This can be handled using `alloc`, but I'm not sure how to deal with it better:
- Use something like `#![cfg_attr(all(not(test), not(feature = "use_std")), no_std)]`.
- Use `alloc` for testing.
- Live everything as it is.