### PR TITLE
Remove Vec casting traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = []
 
 [badges]
 travis-ci = { repository = "sdroege/byte-slice-cast", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,33 +61,6 @@
 //!
 //! # }
 //! ```
-//! # Example with `Vec<T>`
-//! ```
-//! # extern crate byte_slice_cast;
-//! # fn main() {
-//! # #[cfg(feature = "alloc")] {
-//! use byte_slice_cast::*;
-//!
-//! let vec = vec![0x0102u16, 0x0304u16, 0x0506u16];
-//! let converted_vec = vec.into_byte_vec();
-//!
-//! if cfg!(target_endian = "big") {
-//!     assert_eq!(converted_vec, &[1, 2, 3, 4, 5, 6]);
-//! } else {
-//!     assert_eq!(converted_vec, &[2, 1, 4, 3, 6, 5]);
-//! }
-//!
-//! let converted_back_vec = converted_vec.into_vec_of::<u16>().unwrap();
-//! assert_eq!(&converted_back_vec[..], &[0x0102u16, 0x0304u16, 0x0506u16]);
-//! # }
-//! # }
-//! ```
-
-#[cfg(feature = "alloc")]
-#[macro_use]
-extern crate alloc;
-#[cfg(feature = "alloc")]
-use self::alloc::vec::*;
 
 use core::{fmt, mem, slice};
 
@@ -110,14 +83,6 @@ pub enum Error {
         dst_type: &'static str,
         src_slice_size: usize,
         dst_type_size: usize,
-    },
-    /// When converting a `Vec<T>` it had a capacity that
-    /// allowed only for a non-integer number of values
-    /// from the output type.
-    CapacityMismatch {
-        dst_type: &'static str,
-        src_vec_capacity: usize,
-        dst_type_capacity: usize,
     },
 }
 
@@ -150,20 +115,6 @@ impl fmt::Display for Error {
                     dst_type
                 )?;
             }
-            Error::CapacityMismatch {
-                dst_type,
-                src_vec_capacity,
-                dst_type_capacity,
-            } => {
-                write!(
-                    f,
-                    "cannot cast a vec into a vec::<{}>: the capacity ({}) of the vec is not divisible by the capacity of ({}) of {}",
-                    dst_type,
-                    src_vec_capacity,
-                    dst_type_capacity,
-                    dst_type
-                )?;
-            }
         }
 
         Ok(())
@@ -182,7 +133,6 @@ impl StdError for Error {
         match *self {
             AlignmentMismatch { .. } => "Alignment Mismatch",
             LengthMismatch { .. } => "Length Mismatch",
-            CapacityMismatch { .. } => "Capacity Mismatch",
         }
     }
 }
@@ -221,23 +171,6 @@ where
     Ok(size_out)
 }
 
-#[cfg(feature = "alloc")]
-fn check_capacity<U>(data: &Vec<u8>) -> Result<usize, Error>
-where
-    U: TypeName,
-{
-    let capacity_out = mem::size_of::<U>();
-    if data.capacity() % capacity_out != 0 {
-        let err = Error::CapacityMismatch {
-            dst_type: U::TYPE_NAME,
-            src_vec_capacity: data.capacity(),
-            dst_type_capacity: capacity_out,
-        };
-        return Err(err);
-    }
-    Ok(capacity_out)
-}
-
 fn check_constraints<U>(data: &[u8]) -> Result<usize, Error>
 where
     U: TypeName,
@@ -250,85 +183,6 @@ where
     let size_out = check_length::<[u8], U>(data)?;
 
     Ok(data.len() / size_out)
-}
-
-#[cfg(feature = "alloc")]
-fn check_vec_constraints<U>(data: &Vec<u8>) -> Result<(usize, usize), Error>
-where
-    U: TypeName,
-{
-    if data.is_empty() {
-        return Ok((0, 0));
-    }
-
-    check_alignment::<[u8], U>(data)?;
-    let size_out = check_length::<[u8], U>(data)?;
-    let capacity_out = check_capacity::<U>(data)?;
-
-    Ok((data.len() / size_out, data.capacity() / capacity_out))
-}
-
-/// Trait for converting from a byte slice to a slice of a fundamental, built-in numeric type.
-///
-/// This trait is an implementation detail. Use the [`AsSliceOf`] and [`AsMutSliceOf`] traits.
-///
-/// [`AsSliceOf`]: trait.AsSliceOf.html
-/// [`AsMutSliceOf`]: trait.AsMutSliceOf.html
-pub unsafe trait FromByteSlice
-where
-    Self: Sized,
-{
-    /// Convert from an immutable byte slice to a immutable slice of a fundamental, built-in
-    /// numeric type
-    fn from_byte_slice<T: AsRef<[u8]> + ?Sized>(slice: &T) -> Result<&[Self], Error>;
-    /// Convert from an mutable byte slice to a mutable slice of a fundamental, built-in numeric
-    /// type
-    fn from_mut_byte_slice<T: AsMut<[u8]> + ?Sized>(slice: &mut T) -> Result<&mut [Self], Error>;
-}
-
-/// Trait for converting from an immutable slice of a fundamental, built-in numeric type to an
-/// immutable byte slice.
-///
-/// This trait is an implementation detail. Use the [`AsByteSlice`] trait.
-///
-/// [`AsByteSlice`]: trait.AsByteSlice.html
-pub unsafe trait ToByteSlice
-where
-    Self: Sized,
-{
-    /// Convert from an immutable slice of a fundamental, built-in numeric type to an immutable
-    /// byte slice
-    fn to_byte_slice<T: AsRef<[Self]> + ?Sized>(slice: &T) -> &[u8];
-}
-
-/// Trait for converting from a mutable slice of a fundamental, built-in numeric type to a mutable
-/// byte slice.
-///
-/// This trait is an implementation detail. Use the [`AsMutByteSlice`] trait.
-///
-/// [`AsMutByteSlice`]: trait.AsMutByteSlice.html
-pub unsafe trait ToMutByteSlice
-where
-    Self: Sized,
-{
-    /// Convert from a mutable slice of a fundamental, built-in numeric type to a mutable byte
-    /// slice
-    fn to_mut_byte_slice<T: AsMut<[Self]> + ?Sized>(slice: &mut T) -> &mut [u8];
-}
-
-/// Trait for converting from a byte `Vec<u8>` to a `Vec<T>` of a fundamental, built-in numeric type.
-///
-/// This trait is an implementation detail. Use the [`IntoVecOf`] trait.
-///
-/// [`IntoVecOf`]: trait.IntoVecOf.html
-#[cfg(feature = "alloc")]
-pub unsafe trait FromByteVec
-where
-    Self: Sized,
-{
-    /// Convert from a byte `Vec<u8>` to a `Vec<T>` of a fundamental, built-in
-    /// numeric type
-    fn from_byte_vec(vec: Vec<u8>) -> Result<Vec<Self>, Error>;
 }
 
 macro_rules! impl_trait(
@@ -390,44 +244,56 @@ macro_rules! impl_trait(
                 }
             }
         }
-
-        #[cfg(feature = "alloc")]
-        unsafe impl FromByteVec for $to {
-            fn from_byte_vec(mut vec: Vec<u8>) -> Result<Vec<$to>, Error> {
-                let (len, capacity) = check_vec_constraints::<$to>(&vec)?;
-                if capacity == 0 {
-                    Ok(vec![])
-                }
-                else {
-                    let ptr = vec.as_mut_ptr();
-                    mem::forget(vec);
-                    unsafe {
-                        Ok(Vec::from_raw_parts(ptr as *mut $to, len, capacity))
-                    }
-                }
-            }
-        }
-
-        #[cfg(feature = "alloc")]
-        impl IntoByteVec for Vec<$to> {
-            fn into_byte_vec(mut self) -> Vec<u8> {
-                if self.capacity() == 0 {
-                    vec![]
-                }
-                else {
-                    let size = mem::size_of::<$to>();
-                    let len = self.len() * size;
-                    let capacity = self.capacity() * size;
-                    let ptr = self.as_mut_ptr();
-                    mem::forget(self);
-                    unsafe {
-                        Vec::from_raw_parts(ptr as *mut u8, len, capacity)
-                    }
-                }
-            }
-        }
     };
 );
+
+/// Trait for converting from a byte slice to a slice of a fundamental, built-in numeric type.
+///
+/// This trait is an implementation detail. Use the [`AsSliceOf`] and [`AsMutSliceOf`] traits.
+///
+/// [`AsSliceOf`]: trait.AsSliceOf.html
+/// [`AsMutSliceOf`]: trait.AsMutSliceOf.html
+pub unsafe trait FromByteSlice
+where
+    Self: Sized,
+{
+    /// Convert from an immutable byte slice to a immutable slice of a fundamental, built-in
+    /// numeric type
+    fn from_byte_slice<T: AsRef<[u8]> + ?Sized>(slice: &T) -> Result<&[Self], Error>;
+    /// Convert from an mutable byte slice to a mutable slice of a fundamental, built-in numeric
+    /// type
+    fn from_mut_byte_slice<T: AsMut<[u8]> + ?Sized>(slice: &mut T) -> Result<&mut [Self], Error>;
+}
+
+/// Trait for converting from an immutable slice of a fundamental, built-in numeric type to an
+/// immutable byte slice.
+///
+/// This trait is an implementation detail. Use the [`AsByteSlice`] trait.
+///
+/// [`AsByteSlice`]: trait.AsByteSlice.html
+pub unsafe trait ToByteSlice
+where
+    Self: Sized,
+{
+    /// Convert from an immutable slice of a fundamental, built-in numeric type to an immutable
+    /// byte slice
+    fn to_byte_slice<T: AsRef<[Self]> + ?Sized>(slice: &T) -> &[u8];
+}
+
+/// Trait for converting from a mutable slice of a fundamental, built-in numeric type to a mutable
+/// byte slice.
+///
+/// This trait is an implementation detail. Use the [`AsMutByteSlice`] trait.
+///
+/// [`AsMutByteSlice`]: trait.AsMutByteSlice.html
+pub unsafe trait ToMutByteSlice
+where
+    Self: Sized,
+{
+    /// Convert from a mutable slice of a fundamental, built-in numeric type to a mutable byte
+    /// slice
+    fn to_mut_byte_slice<T: AsMut<[Self]> + ?Sized>(slice: &mut T) -> &mut [u8];
+}
 
 /// Trait for converting from a byte slice to a slice of a fundamental, built-in numeric type.
 ///
@@ -544,61 +410,6 @@ impl<T: ToMutByteSlice, U: AsMut<[T]> + ?Sized> AsMutByteSlice<T> for U {
     }
 }
 
-/// Trait for converting from a byte `Vec<u8>` to a `Vec<T>` of a fundamental, built-in
-/// numeric type.
-///
-/// # Example
-/// ```no_run
-/// # extern crate byte_slice_cast;
-/// # fn main() {
-/// use byte_slice_cast::*;
-///
-/// let mut vec: Vec<u8> = vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
-/// let converted_vec = vec.into_vec_of::<u16>().unwrap();
-///
-/// if cfg!(target_endian = "big") {
-///     assert_eq!(converted_vec, vec![0x0102, 0x0304, 0x0506]);
-/// } else {
-///     assert_eq!(converted_vec, vec![0x0201, 0x0403, 0x0605]);
-/// }
-/// # }
-/// ```
-#[cfg(feature = "alloc")]
-pub trait IntoVecOf {
-    fn into_vec_of<T: FromByteVec>(self) -> Result<Vec<T>, Error>;
-}
-
-#[cfg(feature = "alloc")]
-impl IntoVecOf for Vec<u8> {
-    fn into_vec_of<T: FromByteVec>(self) -> Result<Vec<T>, Error> {
-        FromByteVec::from_byte_vec(self)
-    }
-}
-
-/// Trait for converting from a `Vec<T>` of a fundamental, built-in numeric type to a
-/// byte `Vec<u8>`.
-///
-/// # Example
-/// ```no_run
-/// # extern crate byte_slice_cast;
-/// # fn main() {
-/// use byte_slice_cast::*;
-///
-/// let mut vec: Vec<u16> = vec![0x0102, 0x0304, 0x0506];
-/// let converted_vec = vec.into_byte_vec();
-///
-/// if cfg!(target_endian = "big") {
-///     assert_eq!(converted_vec, vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8]);
-/// } else {
-///     assert_eq!(converted_vec, vec![2u8, 1u8, 4u8, 3u8, 6u8, 5u8]);
-/// }
-/// # }
-/// ```
-#[cfg(feature = "alloc")]
-pub trait IntoByteVec {
-    fn into_byte_vec(self) -> Vec<u8>;
-}
-
 impl_trait!(u8);
 impl_trait!(u16);
 impl_trait!(u32);
@@ -629,17 +440,6 @@ mod tests {
         assert_eq!(&input, output2);
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn u8_vec() {
-        let input: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        let output = input.clone().into_vec_of::<u8>().unwrap();
-        assert_eq!(input, output);
-
-        let output2: Vec<u8> = input.clone().into_byte_vec();
-        assert_eq!(input, output2);
-    }
-
     #[test]
     fn u16() {
         let slice: [u16; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
@@ -667,44 +467,6 @@ mod tests {
             })
         );
         assert_eq!(bytes.as_slice_of::<u16>(), Ok(slice.as_ref()));
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn u16_into_vec() {
-        let slice: [u16; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
-        let vec: Vec<u16> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            assert_eq!(&byte_vec, &[0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7]);
-        } else {
-            assert_eq!(&byte_vec, &[0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0]);
-        }
-
-        let err_vec = vec![1u8, 2u8, 3u8];
-        assert_eq!(
-            err_vec.clone().into_vec_of::<u16>(),
-            Err(Error::LengthMismatch {
-                dst_type: "u16",
-                src_slice_size: 3,
-                dst_type_size: mem::size_of::<u16>(),
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(13);
-        err_vec.append(&mut vec![1u8, 2u8]);
-        assert_eq!(err_vec.capacity(), 13);
-        assert_eq!(
-            err_vec.into_vec_of::<u16>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "u16",
-                src_vec_capacity: 13,
-                dst_type_capacity: mem::size_of::<u16>(),
-            })
-        );
-
-        assert_eq!(byte_vec.into_vec_of::<u16>(), Ok(vec));
     }
 
     #[cfg(feature = "std")]
@@ -757,43 +519,6 @@ mod tests {
         assert_eq!(bytes.as_slice_of::<u32>(), Ok(slice.as_ref()));
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn u32_vec() {
-        let slice: [u32; 4] = [0, 1, 2, 3];
-        let vec: Vec<u32> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3]);
-        } else {
-            assert_eq!(&byte_vec, &[0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
-        }
-
-        let err_vec = vec![1u8, 2u8, 3u8, 4u8, 5u8];
-        assert_eq!(
-            err_vec.clone().into_vec_of::<u32>(),
-            Err(Error::LengthMismatch {
-                dst_type: "u32",
-                src_slice_size: 5,
-                dst_type_size: mem::size_of::<u32>(),
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(13);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8]);
-        assert_eq!(err_vec.capacity(), 13);
-        assert_eq!(
-            err_vec.into_vec_of::<u32>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "u32",
-                src_vec_capacity: 13,
-                dst_type_capacity: mem::size_of::<u32>(),
-            })
-        );
-        assert_eq!(byte_vec.into_vec_of::<u32>(), Ok(vec));
-    }
-
     #[test]
     fn u64() {
         let slice: [u64; 2] = [0, 1];
@@ -821,43 +546,6 @@ mod tests {
             })
         );
         assert_eq!(bytes.as_slice_of::<u64>(), Ok(slice.as_ref()));
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn u64_vec() {
-        let slice: [u64; 2] = [0, 1];
-        let vec: Vec<u64> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
-        } else {
-            assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]);
-        }
-
-        let err_vec = vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8];
-        assert_eq!(
-            err_vec.clone().into_vec_of::<u64>(),
-            Err(Error::LengthMismatch {
-                dst_type: "u64",
-                src_slice_size: 9,
-                dst_type_size: mem::size_of::<f64>()
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(13);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8]);
-        assert_eq!(err_vec.capacity(), 13);
-        assert_eq!(
-            err_vec.into_vec_of::<u64>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "u64",
-                src_vec_capacity: 13,
-                dst_type_capacity: mem::size_of::<u64>()
-            })
-        );
-        assert_eq!(byte_vec.into_vec_of::<u64>(), Ok(vec));
     }
 
     #[test]
@@ -905,61 +593,6 @@ mod tests {
         assert_eq!(bytes.as_slice_of::<usize>(), Ok(slice.as_ref()));
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn usize_vec() {
-        let slice: [usize; 2] = [0, 1];
-        let vec: Vec<usize> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            if cfg!(target_pointer_width = "16") {
-                assert_eq!(&byte_vec, &[0, 0, 0, 1]);
-            } else if cfg!(target_pointer_width = "32") {
-                assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 1]);
-            } else if cfg!(target_pointer_width = "64") {
-                assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
-            } else {
-                panic!("Unhandled target_endian/target_pointer_width configuration");
-            }
-        } else {
-            if cfg!(target_pointer_width = "16") {
-                assert_eq!(&byte_vec, &[0, 0, 1, 0]);
-            } else if cfg!(target_pointer_width = "32") {
-                assert_eq!(&byte_vec, &[0, 0, 0, 0, 1, 0, 0, 0]);
-            } else if cfg!(target_pointer_width = "64") {
-                assert_eq!(&byte_vec, &[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]);
-            } else {
-                panic!("Unhandled target_endian/target_pointer_width configuration");
-            }
-        }
-
-        let mut err_vec = vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8];
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8]);
-        assert_eq!(
-            err_vec.clone().into_vec_of::<usize>(),
-            Err(Error::LengthMismatch {
-                dst_type: "usize",
-                src_slice_size: 17,
-                dst_type_size: mem::size_of::<usize>()
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(21);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8]);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8]);
-        assert_eq!(err_vec.capacity(), 21);
-        assert_eq!(
-            err_vec.into_vec_of::<usize>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "usize",
-                src_vec_capacity: 21,
-                dst_type_capacity: mem::size_of::<usize>()
-            })
-        );
-        assert_eq!(byte_vec.into_vec_of::<usize>(), Ok(vec));
-    }
-
     #[test]
     fn f32() {
         let slice: [f32; 4] = [2.0, 1.0, 0.5, 0.25];
@@ -1001,55 +634,6 @@ mod tests {
         assert_eq!(bytes.as_slice_of::<f32>(), Ok(slice.as_ref()));
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn f32_vec() {
-        let slice: [f32; 4] = [2.0, 1.0, 0.5, 0.25];
-        let vec: Vec<f32> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            assert_eq!(
-                byte_vec,
-                [
-                    0x40, 0x00, 0x00, 0x00, 0x3f, 0x80, 0x00, 0x00, 0x3f, 0x00, 0x00, 0x00, 0x3e,
-                    0x80, 0x00, 0x00
-                ]
-            );
-        } else {
-            assert_eq!(
-                byte_vec,
-                [
-                    0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x3f, 0x00,
-                    0x00, 0x80, 0x3e
-                ]
-            );
-        };
-
-        let err_vec = vec![1u8, 2u8, 3u8, 4u8, 5u8];
-        assert_eq!(
-            err_vec.clone().into_vec_of::<f32>(),
-            Err(Error::LengthMismatch {
-                dst_type: "f32",
-                src_slice_size: 5,
-                dst_type_size: mem::size_of::<f32>(),
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(13);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8]);
-        assert_eq!(err_vec.capacity(), 13);
-        assert_eq!(
-            err_vec.into_vec_of::<f32>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "f32",
-                src_vec_capacity: 13,
-                dst_type_capacity: mem::size_of::<f32>(),
-            })
-        );
-        assert_eq!(byte_vec.into_vec_of::<f32>(), Ok(vec));
-    }
-
     #[test]
     fn f64() {
         let slice: [f64; 2] = [2.0, 0.5];
@@ -1089,55 +673,6 @@ mod tests {
             })
         );
         assert_eq!(bytes.as_slice_of::<f64>(), Ok(slice.as_ref()));
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn f64_vec() {
-        let slice: [f64; 2] = [2.0, 0.5];
-        let vec: Vec<f64> = Vec::from(slice.as_ref());
-        let byte_vec = vec.clone().into_byte_vec();
-
-        if cfg!(target_endian = "big") {
-            assert_eq!(
-                byte_vec,
-                [
-                    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3f, 0xe0, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00
-                ]
-            );
-        } else {
-            assert_eq!(
-                byte_vec,
-                [
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0xe0, 0x3f
-                ]
-            );
-        };
-
-        let err_vec = vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8];
-        assert_eq!(
-            err_vec.clone().into_vec_of::<f64>(),
-            Err(Error::LengthMismatch {
-                dst_type: "f64",
-                src_slice_size: 9,
-                dst_type_size: 8
-            })
-        );
-
-        let mut err_vec: Vec<u8> = Vec::with_capacity(13);
-        err_vec.append(&mut vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8]);
-        assert_eq!(err_vec.capacity(), 13);
-        assert_eq!(
-            err_vec.into_vec_of::<f64>(),
-            Err(Error::CapacityMismatch {
-                dst_type: "f64",
-                src_vec_capacity: 13,
-                dst_type_capacity: mem::size_of::<f64>()
-            })
-        );
-        assert_eq!(byte_vec.into_vec_of::<f64>(), Ok(vec));
     }
 
     #[test]
@@ -1300,26 +835,10 @@ mod tests {
         assert_eq!(bytes, &[]);
     }
 
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn u16_empty_vec_into_byte_vec() {
-        let vec: Vec<u16> = vec![];
-        let byte_vec = vec.clone().into_byte_vec();
-        assert_eq!(byte_vec, vec![]);
-    }
-
     #[test]
     fn u16_empty_from_byte_slice() {
         let bytes: [u8; 0] = [];
         let slice = bytes.as_slice_of::<u16>().unwrap();
         assert_eq!(slice, &[]);
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn byte_vec_into_u16_empty_vec() {
-        let byte_vec: Vec<u8> = vec![];
-        let vec = byte_vec.clone().into_vec_of::<u16>().unwrap();
-        assert_eq!(vec, vec![]);
     }
 }


### PR DESCRIPTION
These are actually unsound as the alloc trait requires that memory
allocated with a specific alignment must be also deallocated with
exactly the same alignment.

This makes it impossible to cast a `Vec<u16>` as `Vec<u8>` and then drop
it as `u8` and `u16` have different alignment requirements.