### PR TITLE
Add support for unit type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,26 @@ impl_trait!(f32);
 impl_trait!(f64);
 impl_trait!(usize);
 impl_trait!(isize);
-impl_trait!(());
+
+impl TypeName for () {
+    const TYPE_NAME: &'static str = "()";
+}
+
+unsafe impl ToByteSlice for () {
+    fn to_byte_slice<T: AsRef<[()]> + ?Sized>(slice: &T) -> &[u8] {
+        let slice = slice.as_ref();
+        let len = slice.len() * mem::size_of::<()>();
+        unsafe { slice::from_raw_parts(slice.as_ptr() as *const u8, len) }
+    }
+}
+
+unsafe impl ToMutByteSlice for () {
+    fn to_mut_byte_slice<T: AsMut<[()]> + ?Sized>(slice: &mut T) -> &mut [u8] {
+        let slice = slice.as_mut();
+        let len = slice.len() * mem::size_of::<()>();
+        unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,18 +430,14 @@ impl TypeName for () {
 }
 
 unsafe impl ToByteSlice for () {
-    fn to_byte_slice<T: AsRef<[()]> + ?Sized>(slice: &T) -> &[u8] {
-        let slice = slice.as_ref();
-        let len = slice.len() * mem::size_of::<()>();
-        unsafe { slice::from_raw_parts(slice.as_ptr() as *const u8, len) }
+    fn to_byte_slice<T: AsRef<[()]> + ?Sized>(_: &T) -> &[u8] {
+        &[]
     }
 }
 
 unsafe impl ToMutByteSlice for () {
-    fn to_mut_byte_slice<T: AsMut<[()]> + ?Sized>(slice: &mut T) -> &mut [u8] {
-        let slice = slice.as_mut();
-        let len = slice.len() * mem::size_of::<()>();
-        unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) }
+    fn to_mut_byte_slice<T: AsMut<[()]> + ?Sized>(_: &mut T) -> &mut [u8] {
+        &mut []
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,7 @@ impl_trait!(f32);
 impl_trait!(f64);
 impl_trait!(usize);
 impl_trait!(isize);
+impl_trait!(());
 
 #[cfg(test)]
 mod tests {
@@ -842,5 +843,13 @@ mod tests {
         let bytes: [u8; 0] = [];
         let slice = bytes.as_slice_of::<u16>().unwrap();
         assert_eq!(slice, &[]);
+    }
+
+    #[test]
+    fn unit() {
+        let slice: [(); 4] = [(), (), (), ()];
+        let bytes = slice.as_byte_slice();
+
+        assert_eq!(bytes, &[]);
     }
 }


### PR DESCRIPTION
Thanks for this useful crate! I was missing support for `()` in a [project](https://github.com/s1ck/graph) so I added it.