### PR TITLE
Add support for primitive arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+Cargo.lock


### PR DESCRIPTION
* Add support for primitive arrays via const generics.
* Add a few basic tests.
* Add Cargo.lock to the .gitignore so the lockfile doesn't
    get accidentally added.

Since the layout of arrays [seem well defined](https://doc.rust-lang.org/stable/reference/type-layout.html#array-layout), this should be safe to do. However this will increase the minimum compiler version requirements because of the usage of const generic.

I was pretty lazy on the tests and only added the bare minimum. The type name is not ideal either due to stringify not picking up the generic constant.