### PR TITLE
fix tests for current stable Rust (1.81)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -983,14 +983,14 @@ mod tests {
         assert_eq!(
             (bytes[1..]).as_slice_of::<[u16; 3]>(),
             Err(Error::AlignmentMismatch {
-                dst_type: "[u16 ; N]",
+                dst_type: "[u16; N]",
                 dst_minimum_alignment: mem::align_of::<[u16; 3]>()
             })
         );
         assert_eq!(
             (bytes[0..4]).as_slice_of::<[u16; 3]>(),
             Err(Error::LengthMismatch {
-                dst_type: "[u16 ; N]",
+                dst_type: "[u16; N]",
                 src_slice_size: 4,
                 dst_type_size: 6
             })


### PR DESCRIPTION
I can't tell which Rust version this changed with, but the formatting of `[<type>; <length>]` array types has changed recently. I'd have checked the CI logs to see which Rust version the CI last passed with, but the logs have been garbage collected.

I have checked that the changes in this PR make tests pass with Rust stable (1.81) and nightly (1.83).
